### PR TITLE
Index fixes

### DIFF
--- a/html/bookindex.html
+++ b/html/bookindex.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -248,7 +247,6 @@
               <li>height, <a href="chapter2.html#§2.16">2.16</a>, <a href="chapter9.html#§9.96">9.96</a>, <a href="chapter10.html#§10.158">10.158</a></li>
               <li>rate of rise, <a href="chapter2.html#§2.12">2.12</a></li>
               <li>radioactivity in, <a href="chapter9.html#§9.61">9.61</a></li>
-
               <li>radius, <a href="chapter2.html#§2.16">2.16</a></li>
               <li>scavenging, <a href="chapter9.html#§9.67">9.67</a>-<a href="chapter9.html#§9.74">9.74</a></li>
               <li>stabilized, <a href="chapter2.html#§2.15">2.15</a>, <a href="chapter9.html#§9.84">9.84</a>, <a href="chapter9.html#§9.91">9.91</a>, <a href="chapter9.html#§9.96">9.96</a></li>
@@ -289,7 +287,6 @@
           <li>underwater, <a href="chapter6.html#§6.60">6.60</a>, <a href="chapter6.html#§6.61">6.61</a></li>
         </ol>
       </li>
-
       <li>Critical mass (or size), <a href="chapter1.html#§1.46">1.46</a>-<a href="chapter1.html#§1.53">1.53</a>
         <ol>
           <li>attainment in weapon, <a href="chapter1.html#§1.51">1.51</a>-<a href="chapter1.html#§1.53">1.53</a></li>
@@ -797,7 +794,6 @@
               </li>
               <li>cylindrical, <a href="chapter4.html#§4.57">4.57</a>-<a href="chapter4.html#§4.16">4.16</a></li>
               <li>open-frame, <a href="chapter4.html#§4.52">4.52</a>-<a href="chapter4.html#§4.56">4.56</a></li>
-
             </ol>
           </li>
         </ol>
@@ -911,7 +907,6 @@
               <li>on plants, <a href="chapter12.html#§12.240">12.240</a>-<a href="chapter12.html#§12.243">12.243</a>, <a href="chapter12.html#§12.255">12.255</a>-<a href="chapter12.html#§12.265">12.265</a></li>
             </ol>
           </li>
-
           <li>initial, <i>see</i> <a href="#InitialNuclearRadiation" class="xref">Initial nuclear radiation</a>
           <li>injuries, <i>see</i> <a href="#RadiationInjury" class="xref">Radiation injury</a>
           <li>prompt, <a href="chapter2.html#§2.41">2.41</a></li>
@@ -922,7 +917,6 @@
           <li>from underwater burst, <a href="chapter2.html#§2.77">2.77</a>-<a href="chapter2.html#§2.79">2.79</a>, <a href="chapter2.html#§2.81">2.81</a>, <a href="chapter2.html#§2.82">2.82</a>, <a href="chapter2.html#§2.89">2.89</a></li>
         </ol>
       </li>
-
       <li id="NuclearWeapons">Nuclear weapons, <a href="chapter1.html#§1.02">1.02</a>, <a href="chapter1.html#§1.11">1.11</a>, <a href="chapter1.html#§1.19">1.19</a>-<a href="chapter1.html#§1.21">1.21</a>, <a href="chapter1.html#§1.51">1.51</a>-<a href="chapter1.html#§1.72">1.72</a>, <i>see also</i> <a href="#NuclearExplosion" class="xref">Nuclear explosions</a>
         <ol>
           <li>boosted, <a href="chapter1.html#§1.72">1.72</a></li>
@@ -935,7 +929,6 @@
           <li>yield, <a href="chapter1.html#§1.20">1.20</a>, <a href="chapter1.html#§1.21">1.21</a></li>
         </ol>
       </li>
-
       <li>Nucleus, atomic, <a href="chapter1.html#§1.08">1.08</a></li>
       <li>Nuclide, <a href="chapter1.html#§1.10">1.10</a>
         <ol>
@@ -987,7 +980,6 @@
           <li>Polar front, <a href="chapter9.html#§9.127">9.127</a></li>
         </ol>
       </li>
-
       <li>Precursor, blast wave, <a href="chapter3.html#§3.49">3.49</a>, <a href="chapter3.html#§3.79">3.79</a>-<a href="chapter3.html#§3.85">3.85</a>
         <ol>
           <li>loading, <a href="chapter4.html#§4.67">4.67</a></li>
@@ -1360,7 +1352,6 @@
       <li>Wind (dynamic pressure), <a href="chapter3.html#§3.07">3.07</a>, <a href="chapter3.html#§3.08">3.08</a>, <a href="chapter3.html#§3.13">3.13</a>, <a href="chapter3.html#§3.14">3.14</a>, <a href="chapter3.html#§3.16">3.16</a>
         <ol>
           <li>velocity, <a href="chapter3.html#§3.07">3.07</a>, <a href="chapter3.html#§3.55">3.55</a></li>
-
         </ol>
       </li>
       <li>Wood, thermal radiation effects, <a href="chapter7.html#§7.37">7.37</a>, <a href="chapter7.html#§7.38">7.38</a>, <a href="chapter7.html#§7.40">7.40</a>, <a href="chapter7.html#§7.44">7.44</a></li>
@@ -1387,5 +1378,4 @@
   </main>
 
 </body>
-
 </html>

--- a/html/bookindex.html
+++ b/html/bookindex.html
@@ -80,7 +80,10 @@
           <li>ground shock, <a href="chapter3.html#§3.51">3.51</a>, <a href="chapter3.html#§3.52">3.52</a></li>
           <li>injuries, <i>see</i> <a href="#Injuries" class="xref">Injuries</a></li>
           <li>nuclear radiation, <a href="chapter2.html#§2.41">2.41</a>-<a href="chapter2.html#§2.45">2.45</a>, <i>see also</i> <a href="#NuclearRadiation" class="xref">Nuclear radiation</a></li>
-          <li>radioactive cloud, <i>see</i> <a href="#2112" class="xref">Cloud contamination</a>, <a href="chapter9.html#§9.48">9.48</a>, <a href="chapter9.html#§9.49">9.49</a></li>
+          <li>radioactive cloud, <i>see</i> <a href="#Cloud" class="xref">Cloud</a>
+            <ol>
+              <li>contamination, <a href="chapter9.html#§9.48">9.48</a>, <a href="chapter9.html#§9.49">9.49</a></li>
+            </ol>
           <li>radio and radar effects, <i>see</i> <a href="#RadioAndRadar" class="xref">Radio and radar</a></li>
           <li>thermal radiation, <a href="chapter2.html#§2.38">2.38</a>-<a href="chapter2.html#§2.40">2.40</a>, <i>see also</i> <a href="#Thermal radiation" class="xref">Thermal radiation</a></li>
         </ol>
@@ -237,7 +240,7 @@
       <li>Chain reaction, <i>see</i> <a href="#Fission" class="xref">Fission</a></li>
       <li>Chimney, in underground burst, <a href="chapter2.html#§2.103">2.103</a>, <a href="chapter6.html#§6.88">6.88</a>, <a href="chapter6.html#§6.89">6.89</a></li>
       <li>Clean weapon, <i>see</i> <a href="#NuclearWeapons" class="xref">Nuclear weapons</a></li>
-      <li>Cloud, condensation, <a href="chapter2.html#§2.47">2.47</a>-<a href="chapter2.html#§2.50">2.50</a>, <a href="chapter2.html#§2.66">2.66</a>
+      <li id="Cloud">Cloud, condensation, <a href="chapter2.html#§2.47">2.47</a>-<a href="chapter2.html#§2.50">2.50</a>, <a href="chapter2.html#§2.66">2.66</a>
         <ol>
           <li>radioactive, <a href="chapter2.html#§2.06">2.06</a>-<a href="chapter2.html#§2.17">2.17</a>, <a href="chapter2.html#§2.19">2.19</a>, <a href="chapter2.html#§2.43">2.43</a>, <a href="chapter2.html#§2.68">2.68</a>, <a href="chapter2.html#§2.97">2.97</a>, <a href="chapter9.html#§9.07">9.07</a>-<a href="chapter9.html#§9.09">9.09</a>
             <ol>
@@ -351,7 +354,10 @@
       <li>Decibel, <a href="chapter10.html#§10.126">10.126</a></li>
       <li>Detection ionizing radiation, <i>see</i> <a href="#Measurement" class="xref">Measurement</a></li>
       <li>Deuterium fusion reactions, <a href="chapter1.html#§1.16">1.16</a>, <a href="chapter1.html#§1.67">1.67</a>-<a href="chapter1.html#§1.71">1.71</a></li>
-      <li>Diffraction loading, <i>see</i> <a href="#2112" class="xref">Loading-sensitive structures</a>, <a href="chapter5.html#§5.139">5.139</a>-<a href="chapter5.html#§5.145">5.145</a></li>
+      <li>Diffraction loading, <i>see</i> <a href="Loading" class="xref">Loading</a>
+        <ol>
+          <li>-sensitive structures, <a href="chapter5.html#§5.139">5.139</a>-<a href="chapter5.html#§5.145">5.145</a></li>
+        </ol>
       <li>Dirty weapons, <a href="chapter9.html#§9.47">9.47</a></li>
       <li>Dose (and dose rate), radiation, <a href="chapter8.html#§8.17">8.17</a>-<a href="chapter8.html#§8.19">8.19</a>
         <ol>
@@ -364,7 +370,10 @@
         </ol>
       </li>
       <li>Dosimeter, <a href="chapter8.html#§8.21">8.21</a>, <a href="chapter8.html#§8.24">8.24</a>, <a href="chapter8.html#§8.29">8.29</a></li>
-      <li>Drag loading, <i>see</i> <a href="#2112" class="xref">Loading-sensitive structures</a>, <a href="chapter5.html#§5.146">5.146</a>-<a href="chapter5.html#§5.154">5.154</a></li>
+      <li>Drag loading, <i>see</i> <a href="#Loading" class="xref">Loading</a>
+        <ol>
+          <li>-sensitive structures, <a href="chapter5.html#§5.146">5.146</a>-<a href="chapter5.html#§5.154">5.154</a></li>
+        </ol>
       <li>Ductility, materials and structures, <a href="chapter5.html#§5.14">5.14</a>-<a href="chapter5.html#§5.18">5.18</a></li>
       <li id="DynamicPressure">Dynamic pressure, <a href="chapter3.html#§3.06">3.06</a>-<a href="chapter3.html#§3.08">3.08</a>, <a href="chapter3.html#§3.13">3.13</a>-<a href="chapter3.html#§3.20">3.20</a>
         <ol>
@@ -452,7 +461,7 @@
               <li>distribution, <a href="chapter9.html#§9.75">9.75</a>-<a href="chapter9.html#§9.113">9.113</a></li>
             </ol>
           </li>
-          <li>contours, <i>see</i> Fallout patterns</li>
+          <li>contours, <i>see</i> <a href="#FalloutPatterns" class="xref">Fallout patterns</a></li>
           <li>decay, <a href="chapter1.html#§1.64">1.64</a>, <a href="chapter9.html#§9.12">9.12</a>-<a href="chapter9.html#§9.30">9.30</a>, <a href="chapter9.html#§9.145">9.145</a>-<a href="chapter9.html#§9.153">9.153</a>
             <ol>
               <li>half-residence time, <a href="chapter9.html#§9.133">9.133</a></li>
@@ -819,7 +828,8 @@
       </li>
       <li>Million electron volt (or MeV), <a href="chapter1.html#§1.42">1.42</a></li>
       <li>Mobile homes, damage, <a href="chapter5.html#§5.80">5.80</a>-<a href="chapter5.html#§5.84">5.84</a></li>
-      <li>Monitoring, ionizing radiation, <i>see</i> <a href="#2112" class="xref">Measurement Mutations</a>, <i>see</i> <a href="#GeneticEffects" class="xref">Genetic effects</a></li>
+      <li>Monitoring, ionizing radiation, <i>see</i> <a href="#Measurement" class="xref">Measurement</a>
+      <li>Mutations, <i>see</i> <a href="#GeneticEffects" class="xref">Genetic effects</a></li>
     </ol>
 
     <ol>
@@ -866,7 +876,8 @@
       <li>Nitrogen, neutron reaction, <a href="chapter8.html#§8.11">8.11</a>, <a href="chapter8.html#§8.54">8.54</a>, <a href="chapter8.html#§8.56">8.56</a>, <a href="chapter8.html#§8.110">8.110</a>, <a href="chapter9.html#§9.34">9.34</a></li>
       <li id="NuclearExplosion">Nuclear explosion, blast wave, <a href="chapter1.html#§1.01">1.01</a>, <i>see also</i> <a href="#Blast" class="xref">Blast</a>; <a href="#Shock" class="xref">Shock</a>
         <ol>
-          <li>casualties, <i>see</i> <a href="#2112" class="xref">Casualties characteristics</a>, <a href="chapter1.html#§1.01">1.01</a>-<a href="chapter1.html#§1.23">1.23</a></li>
+          <li>casualties, <i>see</i> <a href="#Casualties" class="xref">Casualties</a></li>
+          <li>characteristics, <a href="chapter1.html#§1.01">1.01</a>-<a href="chapter1.html#§1.23">1.23</a></li>
           <li>and conventional explosions, <a href="chapter1.html#§1.01">1.01</a>-<a href="chapter1.html#§1.03">1.03</a></li>
           <li>damage, <i>see</i> <a href="#Damage" class="xref">Damage</a></li>
           <li>description, air burst, <a href="chapter2.html#§2.03">2.03</a>-<a href="chapter2.html#§2.51">2.51</a>, <i>see also</i> <a href="#AirBurst" class="xref">Air burst</a>
@@ -877,7 +888,8 @@
               <li>underwater burst, <a href="chapter2.html#§2.63">2.63</a>-<a href="chapter2.html#§2.89">2.89</a></li>
             </ol>
           </li>
-          <li>fireball development, <i>see</i> <a href="#2112" class="xref">Fireball incendiary effects</a>, <i>see</i> <a href="#Fires" class="xref">Fires</a></li>
+          <li>fireball development, <i>see</i> <a href="#Fireball" class="xref">Fireball</a>
+          <li>incendiary effects, <i>see</i> <a href="#Fires" class="xref">Fires</a></li>
           <li>injuries, <i>see</i> <a href="#Injuries" class="xref">Injuries</a>; <a href="#RadiationInjury" class="xref">Radiation injury</a></li>
           <li>ionization, <i>see</i> Ionization</li>
           <li>nuclear radiation, <i>see</i> <a href="#NuclearRadiation" class="xref">Nuclear radiation</a></li>
@@ -900,7 +912,9 @@
             </ol>
           </li>
 
-          <li>initial, <i>see</i> <a href="#2112" class="xref">Initial nuclear radiation injuries</a>, <i>see</i> <a href="#2112" class="xref">Radiation injury prompt</a>, <a href="chapter2.html#§2.41">2.41</a></li>
+          <li>initial, <i>see</i> <a href="#InitialNuclearRadiation" class="xref">Initial nuclear radiation</a>
+          <li>injuries, <i>see</i> <a href="#RadiationInjury" class="xref">Radiation injury</a>
+          <li>prompt, <a href="chapter2.html#§2.41">2.41</a></li>
           <li>residual, <i>see</i> <a href="#ResidualNuclearRadiation" class="xref">Residual nuclear radiation</a></li>
           <li>from surface burst, <a href="chapter2.html#§2.23">2.23</a>-<a href="chapter2.html#§2.31">2.31</a>, <a href="chapter8.html#§8.37">8.37</a>, <a href="chapter8.html#§8.65">8.65</a>, <a href="chapter9.html#§9.50">9.50</a>-<a href="chapter9.html#§9.52">9.52</a></li>
           <li>transmission factors, <a href="chapter8.html#§8.72">8.72</a>, <a href="chapter9.html#§9.120">9.120</a></li>
@@ -917,7 +931,8 @@
           <li>fission, <a href="chapter1.html#§1.46">1.46</a>-<a href="chapter1.html#§1.59">1.59</a></li>
           <li>fusion, <a href="chapter1.html#§1.67">1.67</a>-<a href="chapter1.html#§1.72">1.72</a>, <i>see also</i> <a href="#ThermonuclearWeapons" class="xref">Thermonuclear weapons</a></li>
           <li>salted, <a href="chapter9.html#§9.11">9.11</a></li>
-          <li>thermonuclear, <i>see</i> <a href="#2112" class="xref">Thermonuclear weapons yield</a>, <a href="chapter1.html#§1.20">1.20</a>, <a href="chapter1.html#§1.21">1.21</a></li>
+          <li>thermonuclear, <i>see</i> <a href="#ThermonuclearWeapons" class="xref">Thermonuclear weapons</a>
+          <li>yield, <a href="chapter1.html#§1.20">1.20</a>, <a href="chapter1.html#§1.21">1.21</a></li>
         </ol>
       </li>
 
@@ -1007,7 +1022,7 @@
           <li>power, <a href="chapter7.html#§7.74">7.74</a>, <a href="chapter7.html#§7.82">7.82</a>-<a href="chapter7.html#§7.84">7.84</a>, <a href="chapter7.html#§7.86">7.86</a></li>
         </ol>
       </li>
-      <li>Radiation injury, <a href="chapter12.html#§12.90">12.90</a>-<a href="chapter12.html#§12.237">12.237</a>
+      <li id="RadiationInjury">Radiation injury, <a href="chapter12.html#§12.90">12.90</a>-<a href="chapter12.html#§12.237">12.237</a>
         <ol>
           <li>acute, <a href="chapter12.html#§12.102">12.102</a>-<a href="chapter12.html#§12.132">12.132</a></li>
           <li>blood, <a href="chapter12.html#§12.124">12.124</a>-<a href="chapter12.html#§12.132">12.132</a></li>
@@ -1028,7 +1043,7 @@
       <li>Radiation Effects Research Foundation, <a href="chapter12.html#§12.142">12.142</a></li>
       <li>Radiation, nuclear, <i>see</i> <a href="#GammaRay" class="xref">Gamma rays</a>; <a href="#Neutron" class="xref">Neutrons</a>; <a href="#NuclearRadiation" class="xref">Nuclear radiation</a></li>
       <li>Radioactive capture, neutrons, <a href="chapter8.html#§8.08">8.08</a></li>
-      <li>Radioactive cloud, <i>see</i> <a href="#2112" class="xref">Cloud</a></li>
+      <li>Radioactive cloud, <i>see</i> <a href="#Cloud" class="xref">Cloud</a></li>
       <li>Radioactive half-life, <a href="chapter1.html#§1.63">1.63</a></li>
       <li>Radioactivity, <a href="chapter1.html#§1.02">1.02</a>, <a href="chapter1.html#§1.28">1.28</a>-<a href="chapter1.html#§1.30">1.30</a>, <a href="chapter1.html#§1.61">1.61</a>-<a href="chapter1.html#§1.66">1.66</a>, <i>see also</i> <a href="#Fallout" class="xref">Fallout</a>
         <ol>


### PR DESCRIPTION
Only one #2112 link left with no referent, which we can either point to the top-level category (#Fallout) or point to a footnote indicating it’s a broken reference.