### PR TITLE
Fixed grid problems in Chrome

### DIFF
--- a/html/style.css
+++ b/html/style.css
@@ -252,8 +252,14 @@ figure.numbered.equation {
     align-items: center;
     margin-block: 0;
 }
+figure.numbered.equation mjx-container {
+    grid-row: 1;
+    grid-column: 1;
+}
 figure.numbered.equation figcaption {
     display: block;
+    grid-row: 1;
+    grid-column: 2;
     padding: 0;
 }
 


### PR DESCRIPTION
Assigning explicit grid rows and columns to the pieces of numbered equations fixes Chrome’s layout bug.