### PR TITLE
Add missing quotation mark in ch1

### DIFF
--- a/html/chapter1.html
+++ b/html/chapter1.html
@@ -431,7 +431,7 @@ E (\text{radiation}) = 7.6&times;10^{-15}T^{4} \text{ ergs/cm}^{3},
 <h2>ENDNOTES</h2>
 
 <ol>
-<li id="fnote01"><sup>1</sup> The terms “nuclear” and atomic” may be used interchangeably so far as weapons, explosions, and energy are concerned, but “nuclear” is preferred for the reason given in <a href="#§1.11" class="xref">§ 1.11</a>.
+<li id="fnote01"><sup>1</sup> The terms “nuclear” and “atomic” may be used interchangeably so far as weapons, explosions, and energy are concerned, but “nuclear” is preferred for the reason given in <a href="#§1.11" class="xref">§ 1.11</a>.
 <span class="backjump">[ref. <a href="#§1.01">§ 1.01</a>]</span>
 <a href="#fnclosed" class="close">X</a></li>
 <li id="fnote02"><sup>2</sup> The remaining (more technical) sections of this chapter may be omitted without loss of continuity.


### PR DESCRIPTION
I noticed this in @meyerweb's [blog post about formatting the footnotes](https://meyerweb.com/eric/thoughts/2022/09/12/nuclear-footnotes/). No `<span class="sic">…</span>` so I assume this isn't intentional.