### PR TITLE
Fix typo in inline TeX

### DIFF
--- a/html/chapter7.html
+++ b/html/chapter7.html
@@ -1214,7 +1214,7 @@
 
       <aside>
 
-        <p>The curves in Fig. 7.84 show the variation with the scaled time $T/t_{max} of the scaled fireball power, P/P<sub>max</sub></sub> (left ordinate) and of the percent of the total thermal energy emitted, ElE,oI (right ordinate), in the thermal pulse of an air burst.</p>
+        <p>The curves in Fig. 7.84 show the variation with the scaled time $T/t_{max}$ of the scaled fireball power, P/P<sub>max</sub></sub> (left ordinate) and of the percent of the total thermal energy emitted, ElE,oI (right ordinate), in the thermal pulse of an air burst.</p>
         <p><em>Scaling.</em> In order to apply the data in Fig. 7.84 to an explosion of any yield, $W$ kilotons, the following expressions are used for bursts below
           15,000 feet:</p>
 


### PR DESCRIPTION
I am working on a conversion with native MathML and thus processing differently, with hard errors - and I noticed this one. I believe this is an error and it is just untouched by MathJax, or skipped because it doesn't have a whole matching inline token